### PR TITLE
Remove unnecessary environment adjustments

### DIFF
--- a/packages/nuevdb/package.py
+++ b/packages/nuevdb/package.py
@@ -5,7 +5,6 @@
 
 from spack import *
 from spack.pkg.fnal_art.fnal_github_package import *
-from spack.util.prefix import Prefix
 
 
 class Nuevdb(CMakePackage, FnalGithubPackage):
@@ -47,11 +46,5 @@ class Nuevdb(CMakePackage, FnalGithubPackage):
         ]
 
     @sanitize_paths
-    def setup_build_environment(self, build_env):
-        build_env.prepend_path("PATH", Prefix(self.build_directory).bin)
-        build_env.prepend_path("CET_PLUGIN_PATH", Prefix(self.build_directory).lib)
-
-    @sanitize_paths
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
-        run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)

--- a/packages/nug4/package.py
+++ b/packages/nug4/package.py
@@ -5,7 +5,6 @@
 
 from spack import *
 from spack.pkg.fnal_art.fnal_github_package import *
-from spack.util.prefix import Prefix
 
 
 class Nug4(CMakePackage, FnalGithubPackage):
@@ -49,12 +48,6 @@ class Nug4(CMakePackage, FnalGithubPackage):
         ]
 
     @sanitize_paths
-    def setup_build_environment(self, build_env):
-        build_env.prepend_path("CET_PLUGIN_PATH", Prefix(self.build_directory).lib)
-        build_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
-
-    @sanitize_paths
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
-        run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.prepend_path("FHICL_FILE_PATH", self.prefix.fcl)

--- a/packages/nugen/package.py
+++ b/packages/nugen/package.py
@@ -62,10 +62,5 @@ class Nugen(CMakePackage, FnalGithubPackage):
         ]
 
     @sanitize_paths
-    def setup_build_environment(self, build_env):
-        build_env.prepend_path("CET_PLUGIN_PATH", Prefix(self.build_directory).lib)
-
-    @sanitize_paths
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
-        run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)

--- a/packages/nurandom/package.py
+++ b/packages/nurandom/package.py
@@ -44,10 +44,8 @@ class Nurandom(CMakePackage, FnalGithubPackage):
     @sanitize_paths
     def setup_build_environment(self, build_env):
         build_env.prepend_path("CET_PLUGIN_PATH", Prefix(self.build_directory).lib)
-        build_env.prepend_path("ROOT_INCLUDE_PATH", str(self.prefix.include))
 
     @sanitize_paths
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
-        run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.prepend_path("FHICL_FILE_PATH", self.prefix.fcl)

--- a/packages/nusimdata/package.py
+++ b/packages/nusimdata/package.py
@@ -33,12 +33,3 @@ class Nusimdata(CMakePackage, FnalGithubPackage):
     @cmake_preset
     def cmake_args(self):
         return [self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd")]
-
-    @sanitize_paths
-    def setup_build_environment(self, build_env):
-        build_env.prepend_path("LD_LIBRARY_PATH", self.spec["root"].prefix.lib)
-        build_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
-
-    @sanitize_paths
-    def setup_run_environment(self, run_env):
-        run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)


### PR DESCRIPTION
Some `setup_build_environment` methods have been removed for those packages that do not have unit tests.  Also, `ROOT_INCLUDE_PATH` and `LD_LIBRARY_PATH` do not need to be explicitly updated for ROOT's use if the package depends directly on `root`.